### PR TITLE
Fix header z-index to prevent content overlay issues

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -102,7 +102,7 @@ header {
     position: fixed;
     width: 100%;
     top: 0;
-    z-index: 1000;
+    z-index: 9999;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
@@ -824,7 +824,7 @@ footer {
         visibility: hidden;
         transform: translateY(-10px);
         transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
-        z-index: 1000;
+        z-index: 9998;
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     }
 


### PR DESCRIPTION
Changes:
- Increase header z-index from 1000 to 9999 to ensure it stays above all content
- Increase mobile nav menu z-index from 1000 to 9998 to maintain proper layering
- This fixes the issue where scrolling content would appear over the fixed header
- Also fixes mobile menu overlay issues when the hamburger button is clicked

The header now properly stays on top of all page content during scrolling on both mobile and desktop views.