### PR TITLE
Fix header overlay by removing opacity stacking context

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -102,7 +102,7 @@ header {
     position: fixed;
     width: 100%;
     top: 0;
-    z-index: 9999;
+    z-index: 1000;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
@@ -824,7 +824,7 @@ footer {
         visibility: hidden;
         transform: translateY(-10px);
         transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
-        z-index: 9998;
+        z-index: 999;
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -94,18 +94,5 @@ document.addEventListener('DOMContentLoaded', function() {
     window.addEventListener('load', animateElements);
     window.addEventListener('scroll', animateElements);
     
-    // Simple page transition effect
-    const fadeIn = () => {
-        const main = document.querySelector('main');
-        if (main) {
-            main.style.opacity = '0';
-            main.style.transition = 'opacity 0.5s ease';
-            
-            setTimeout(() => {
-                main.style.opacity = '1';
-            }, 50);
-        }
-    };
-    
-    fadeIn();
+    // Removed fadeIn effect on main element to prevent stacking context issues with header
 });

--- a/staticfiles/css/main.css
+++ b/staticfiles/css/main.css
@@ -102,7 +102,7 @@ header {
     position: fixed;
     width: 100%;
     top: 0;
-    z-index: 9999;
+    z-index: 1000;
     box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
 }
 
@@ -741,7 +741,7 @@ footer {
         visibility: hidden;
         transform: translateY(-10px);
         transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s;
-        z-index: 9998;
+        z-index: 999;
         box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     }
     

--- a/staticfiles/js/main.js
+++ b/staticfiles/js/main.js
@@ -94,18 +94,5 @@ document.addEventListener('DOMContentLoaded', function() {
     window.addEventListener('load', animateElements);
     window.addEventListener('scroll', animateElements);
     
-    // Simple page transition effect
-    const fadeIn = () => {
-        const main = document.querySelector('main');
-        if (main) {
-            main.style.opacity = '0';
-            main.style.transition = 'opacity 0.5s ease';
-            
-            setTimeout(() => {
-                main.style.opacity = '1';
-            }, 50);
-        }
-    };
-    
-    fadeIn();
+    // Removed fadeIn effect on main element to prevent stacking context issues with header
 });


### PR DESCRIPTION
Root cause: The fadeIn JavaScript function was setting opacity on the main element, which created a new stacking context. This caused all content within main to render in a separate layer that could overlap the fixed header.

Changes:
- Removed fadeIn effect on main element that was creating stacking context
- Reverted z-index values back to 1000 (header) and 999 (mobile nav)
- The issue was never about z-index values being too low
- The issue was the opacity transition creating an overlapping stacking context

This is the correct fix for the rendering order problem - not inflating z-index values which doesn't solve stacking context issues.

Technical explanation:
When an element has opacity < 1 or transitions involving opacity, it creates a new stacking context. Elements in different stacking contexts are layered based on their context's position in the DOM and their parent contexts, not just their z-index values. Removing the opacity manipulation on main prevents this separate stacking context from being created.