### PR TITLE
Fix blog cards rendering above mobile dropdown menu

### DIFF
--- a/static/css/blog.css
+++ b/static/css/blog.css
@@ -219,6 +219,7 @@ pre code {
     transition: var(--transition);
     position: relative;
     overflow: hidden;
+    z-index: 1; /* Ensure posts render below mobile navigation menu (z-index: 999) */
 }
 
 .post:hover {


### PR DESCRIPTION
Added z-index: 1 to .post elements to ensure they render below the
mobile navigation menu (z-index: 999), preventing blog cards from
overlapping the dropdown on mobile devices.