### PR TITLE
Fix recipe admin add page 500 error

### DIFF
--- a/recipes/admin.py
+++ b/recipes/admin.py
@@ -37,8 +37,11 @@ class RecipeAdminForm(forms.ModelForm):
             self.fields['json_input'].required = False
 
         # Make form fields optional - they'll be populated from JSON in clean()
-        self.fields['name'].required = False
-        self.fields['recipe_data'].required = False
+        # Only modify fields if they exist in the form
+        if 'name' in self.fields:
+            self.fields['name'].required = False
+        if 'recipe_data' in self.fields:
+            self.fields['recipe_data'].required = False
 
     def clean(self):
         cleaned_data = super().clean()


### PR DESCRIPTION
The previous commit caused a KeyError when accessing recipe_data field in the form __init__ method. The recipe_data field is not included in the Django admin fieldsets, so it's excluded from the form fields.

This fix adds existence checks before modifying field properties to prevent KeyError exceptions.