### PR TITLE
Fix form validation error when saving recipes

### DIFF
--- a/recipes/admin.py
+++ b/recipes/admin.py
@@ -38,10 +38,11 @@ class RecipeAdminForm(forms.ModelForm):
 
         # Make form fields optional - they'll be populated from JSON in clean()
         # Only modify fields if they exist in the form
-        if 'name' in self.fields:
-            self.fields['name'].required = False
-        if 'recipe_data' in self.fields:
-            self.fields['recipe_data'].required = False
+        fields_to_make_optional = ['name', 'recipe_data', 'description', 'prep_time',
+                                   'cook_time', 'total_time', 'servings', 'difficulty', 'slug']
+        for field_name in fields_to_make_optional:
+            if field_name in self.fields:
+                self.fields[field_name].required = False
 
     def clean(self):
         cleaned_data = super().clean()


### PR DESCRIPTION
Make all auto-populated fields optional in form __init__ method. These fields (description, prep_time, cook_time, total_time, servings, difficulty, slug) are populated from JSON in the clean() method, so they must be optional at the field validation level.

Previously only name and recipe_data were made optional, causing form validation to fail before clean() could populate the other fields from the JSON input.