### PR TITLE
Add custom save method to ensure recipe_data is saved

### DIFF
--- a/recipes/admin.py
+++ b/recipes/admin.py
@@ -77,6 +77,19 @@ class RecipeAdminForm(forms.ModelForm):
 
         return cleaned_data
 
+    def save(self, commit=True):
+        """Override save to ensure recipe_data is properly set from cleaned_data"""
+        instance = super().save(commit=False)
+
+        # Explicitly set recipe_data from cleaned_data if it was populated
+        if 'recipe_data' in self.cleaned_data:
+            instance.recipe_data = self.cleaned_data['recipe_data']
+
+        if commit:
+            instance.save()
+
+        return instance
+
 
 class PublishStatusFilter(admin.SimpleListFilter):
     """Filter recipes by publish status"""


### PR DESCRIPTION
Override the form's save() method to explicitly set recipe_data from cleaned_data before saving. This ensures that recipe_data, which is populated in clean() but not included in the admin fieldsets, is properly persisted to the database.

Without this, the admin interface may not save recipe_data correctly because the field is not rendered in the HTML form (not in fieldsets).