### PR TITLE
Improve meetupspot performance, correctness, and test coverage

### DIFF
--- a/meetup/services/graph.py
+++ b/meetup/services/graph.py
@@ -206,25 +206,35 @@ def get_station_lookup():
     return _station_lookup
 
 
+def get_journey(graph, from_node, to_node):
+    """
+    Get shortest journey time and path between two nodes in a single
+    Dijkstra call. Returns (time_in_minutes, path_list) or (None, None)
+    if no path exists.
+    """
+    try:
+        length, path = nx.single_source_dijkstra(
+            graph, from_node, to_node, weight='weight')
+        return length, path
+    except (nx.NetworkXNoPath, nx.NodeNotFound):
+        return None, None
+
+
 def get_journey_time(graph, from_node, to_node):
     """
     Get shortest journey time between two nodes in the graph.
     Returns time in minutes, or None if no path exists.
     """
-    try:
-        return nx.shortest_path_length(graph, from_node, to_node, weight='weight')
-    except (nx.NetworkXNoPath, nx.NodeNotFound):
-        return None
+    time, _path = get_journey(graph, from_node, to_node)
+    return time
 
 
 def get_journey_path(graph, from_node, to_node):
     """
     Get shortest path between two nodes. Returns list of node IDs.
     """
-    try:
-        return nx.shortest_path(graph, from_node, to_node, weight='weight')
-    except (nx.NetworkXNoPath, nx.NodeNotFound):
-        return None
+    _time, path = get_journey(graph, from_node, to_node)
+    return path
 
 
 def get_lines_used(graph, path):

--- a/meetup/services/optimizer.py
+++ b/meetup/services/optimizer.py
@@ -11,7 +11,7 @@ Uses the local NetworkX graph for all journey time calculations.
 """
 import math
 import networkx as nx
-from .graph import get_graph, get_stations, get_journey_time, get_journey_path, get_lines_used
+from .graph import get_graph, get_stations, get_journey, get_lines_used
 from .walking import find_nearest_stations, haversine_distance
 
 # How far from the centroid to search for candidate stations (km)
@@ -94,13 +94,13 @@ def _get_journey_details(graph, from_node, to_station_id):
     """
     Get detailed journey info from a node to a station hub.
     Returns dict with time, lines used, and path info.
+    Uses a single Dijkstra call for both time and path.
     """
     hub_node = str(to_station_id)
-    time = get_journey_time(graph, from_node, hub_node)
+    time, path = get_journey(graph, from_node, hub_node)
     if time is None:
         return None
 
-    path = get_journey_path(graph, from_node, hub_node)
     lines = get_lines_used(graph, path) if path else set()
 
     return {
@@ -260,6 +260,10 @@ def calculate_meetup_spots(people):
                     'lat': s['lat'],
                     'lon': s['lon'],
                     'score': round(s[key], 1),
+                    'score_fairness': round(s['score_fairness'], 1),
+                    'score_efficiency': round(s['score_efficiency'], 1),
+                    'score_quick_arrival': round(s['score_quick_arrival'], 1),
+                    'score_easy_home': round(s['score_easy_home'], 1),
                     'outbound_details': s['outbound_details'],
                     'return_details': s['return_details'],
                     'lines_used': s['lines_used'],

--- a/meetup/tests/test_disruptions.py
+++ b/meetup/tests/test_disruptions.py
@@ -1,0 +1,120 @@
+from unittest.mock import patch, MagicMock
+from django.test import TestCase
+from meetup.services.disruptions import get_line_disruptions
+
+
+class DisruptionsTest(TestCase):
+    @patch('meetup.services.disruptions.requests.get')
+    def test_returns_disrupted_lines(self, mock_get):
+        """Lines with severity < 10 should be returned as disruptions."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                'name': 'Central',
+                'lineStatuses': [
+                    {
+                        'statusSeverity': 5,
+                        'statusSeverityDescription': 'Minor Delays',
+                        'reason': 'Signal failure at Bank',
+                    },
+                ],
+            },
+            {
+                'name': 'Northern',
+                'lineStatuses': [
+                    {
+                        'statusSeverity': 10,
+                        'statusSeverityDescription': 'Good Service',
+                    },
+                ],
+            },
+        ]
+        mock_get.return_value = mock_response
+
+        disruptions = get_line_disruptions()
+        self.assertEqual(len(disruptions), 1)
+        self.assertEqual(disruptions[0]['line'], 'Central')
+        self.assertEqual(disruptions[0]['status'], 'Minor Delays')
+        self.assertIn('Signal failure', disruptions[0]['reason'])
+
+    @patch('meetup.services.disruptions.requests.get')
+    def test_filters_to_requested_lines(self, mock_get):
+        """Should only return disruptions for requested lines."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                'name': 'Central',
+                'lineStatuses': [
+                    {'statusSeverity': 5, 'statusSeverityDescription': 'Delays'},
+                ],
+            },
+            {
+                'name': 'Victoria',
+                'lineStatuses': [
+                    {'statusSeverity': 3, 'statusSeverityDescription': 'Suspended'},
+                ],
+            },
+        ]
+        mock_get.return_value = mock_response
+
+        # Only ask about Victoria
+        disruptions = get_line_disruptions(['Victoria'])
+        self.assertEqual(len(disruptions), 1)
+        self.assertEqual(disruptions[0]['line'], 'Victoria')
+
+    @patch('meetup.services.disruptions.requests.get')
+    def test_good_service_not_included(self, mock_get):
+        """Lines with severity 10 (Good Service) should not appear."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                'name': 'Central',
+                'lineStatuses': [
+                    {'statusSeverity': 10, 'statusSeverityDescription': 'Good Service'},
+                ],
+            },
+        ]
+        mock_get.return_value = mock_response
+
+        disruptions = get_line_disruptions()
+        self.assertEqual(len(disruptions), 0)
+
+    @patch('meetup.services.disruptions.requests.get')
+    def test_api_failure_returns_empty(self, mock_get):
+        """Network errors should return empty list, not crash."""
+        import requests
+        mock_get.side_effect = requests.RequestException("timeout")
+        disruptions = get_line_disruptions()
+        self.assertEqual(disruptions, [])
+
+    @patch('meetup.services.disruptions.requests.get')
+    def test_non_200_returns_empty(self, mock_get):
+        """Non-200 response should return empty list."""
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_get.return_value = mock_response
+
+        disruptions = get_line_disruptions()
+        self.assertEqual(disruptions, [])
+
+    @patch('meetup.services.disruptions.requests.get')
+    def test_line_name_matching_case_insensitive(self, mock_get):
+        """Line name matching should be case-insensitive."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                'name': 'Central',
+                'lineStatuses': [
+                    {'statusSeverity': 5, 'statusSeverityDescription': 'Delays'},
+                ],
+            },
+        ]
+        mock_get.return_value = mock_response
+
+        # Query with different case
+        disruptions = get_line_disruptions(['central'])
+        self.assertEqual(len(disruptions), 1)

--- a/meetup/tests/test_views.py
+++ b/meetup/tests/test_views.py
@@ -1,7 +1,7 @@
 import json
 from unittest.mock import patch
 from django.test import TestCase, Client
-from meetup.models import MeetupSession, Person
+from meetup.models import MeetupSession, Person, MeetupResult
 
 
 class IndexViewTest(TestCase):
@@ -39,6 +39,10 @@ class AutocompleteViewTest(TestCase):
         self.assertEqual(len(data['results']), 1)
         self.assertEqual(data['results'][0]['label'], 'Old Street')
 
+    def test_autocomplete_rejects_post(self):
+        response = self.client.post('/meetup/api/autocomplete/')
+        self.assertEqual(response.status_code, 405)
+
 
 class CalculateViewTest(TestCase):
     def test_calculate_requires_post(self):
@@ -57,6 +61,18 @@ class CalculateViewTest(TestCase):
         response = self.client.post(
             '/meetup/calculate/',
             json.dumps({'people': []}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_calculate_validates_required_fields(self):
+        """People with missing fields should return 400."""
+        response = self.client.post(
+            '/meetup/calculate/',
+            json.dumps({'people': [
+                {'name': 'Alice'},
+                {'name': 'Bob'},
+            ]}),
             content_type='application/json',
         )
         self.assertEqual(response.status_code, 400)
@@ -96,38 +112,206 @@ class CalculateViewTest(TestCase):
         session = MeetupSession.objects.get(uuid=result['session_uuid'])
         self.assertEqual(session.people.count(), 2)
 
+    @patch('meetup.views.get_line_disruptions')
+    def test_calculate_saves_all_scoring_modes(self, mock_disruptions):
+        """Results should be saved for all 4 scoring modes, not just fairness."""
+        mock_disruptions.return_value = []
+        data = {
+            'people': [
+                {
+                    'name': 'Alice',
+                    'origin_lat': 51.5155, 'origin_lon': -0.0715,
+                    'origin_label': 'Whitechapel',
+                    'home_lat': 51.5322, 'home_lon': -0.1058,
+                    'home_label': 'Angel',
+                },
+                {
+                    'name': 'Bob',
+                    'origin_lat': 51.4627, 'origin_lon': -0.1145,
+                    'origin_label': 'Brixton',
+                    'home_lat': 51.4694, 'home_lon': -0.0693,
+                    'home_label': 'Peckham',
+                },
+            ],
+        }
+        response = self.client.post(
+            '/meetup/calculate/',
+            json.dumps(data),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        result = json.loads(response.content)
+        session = MeetupSession.objects.get(uuid=result['session_uuid'])
+        saved = session.results.all()
+
+        # Every saved result should have all 4 scores populated
+        for r in saved:
+            self.assertIsNotNone(r.score_fairness,
+                                 f"{r.station_name} missing score_fairness")
+            self.assertIsNotNone(r.score_efficiency,
+                                 f"{r.station_name} missing score_efficiency")
+            self.assertIsNotNone(r.score_quick_arrival,
+                                 f"{r.station_name} missing score_quick_arrival")
+            self.assertIsNotNone(r.score_easy_home,
+                                 f"{r.station_name} missing score_easy_home")
+
+    @patch('meetup.views.get_line_disruptions')
+    def test_calculate_returns_disruptions(self, mock_disruptions):
+        """Disruption warnings should be included in the response."""
+        mock_disruptions.return_value = [
+            {'line': 'Central', 'status': 'Minor Delays', 'reason': 'Signal failure'},
+        ]
+        data = {
+            'people': [
+                {
+                    'name': 'Alice',
+                    'origin_lat': 51.5155, 'origin_lon': -0.0715,
+                    'origin_label': 'Whitechapel',
+                    'home_lat': 51.5322, 'home_lon': -0.1058,
+                    'home_label': 'Angel',
+                },
+                {
+                    'name': 'Bob',
+                    'origin_lat': 51.4627, 'origin_lon': -0.1145,
+                    'origin_label': 'Brixton',
+                    'home_lat': 51.4694, 'home_lon': -0.0693,
+                    'home_label': 'Peckham',
+                },
+            ],
+        }
+        response = self.client.post(
+            '/meetup/calculate/',
+            json.dumps(data),
+            content_type='application/json',
+        )
+        result = json.loads(response.content)
+        self.assertIn('disruptions', result)
+        self.assertEqual(len(result['disruptions']), 1)
+        self.assertEqual(result['disruptions'][0]['line'], 'Central')
+
 
 class ResultsViewTest(TestCase):
+    def _create_session_with_results(self):
+        """Helper: create a session with people and saved MeetupResult records."""
+        session = MeetupSession.objects.create()
+        Person.objects.create(
+            session=session, name='Alice',
+            origin_label='Whitechapel', origin_lat=51.5155, origin_lon=-0.0715,
+            home_label='Angel', home_lat=51.5322, home_lon=-0.1058,
+        )
+        Person.objects.create(
+            session=session, name='Bob',
+            origin_label='Brixton', origin_lat=51.4627, origin_lon=-0.1145,
+            home_label='Peckham', home_lat=51.4694, home_lon=-0.0693,
+        )
+        MeetupResult.objects.create(
+            session=session,
+            station_name='Bank',
+            station_lat=51.5133, station_lon=-0.0886,
+            score_fairness=25.0, score_efficiency=30.0,
+            score_quick_arrival=15.0, score_easy_home=12.0,
+            journey_details_json=json.dumps({
+                'outbound': [
+                    {'person': 'Alice', 'direction': 'outbound',
+                     'time_minutes': 10.0, 'lines': ['Central']},
+                    {'person': 'Bob', 'direction': 'outbound',
+                     'time_minutes': 15.0, 'lines': ['Victoria']},
+                ],
+                'return': [
+                    {'person': 'Alice', 'direction': 'return',
+                     'time_minutes': 8.0, 'lines': ['Northern']},
+                    {'person': 'Bob', 'direction': 'return',
+                     'time_minutes': 12.0, 'lines': ['Victoria']},
+                ],
+            }),
+            google_maps_url='https://www.google.com/maps/search/?api=1&query=51.5133,-0.0886',
+        )
+        MeetupResult.objects.create(
+            session=session,
+            station_name='Waterloo',
+            station_lat=51.5036, station_lon=-0.1143,
+            score_fairness=28.0, score_efficiency=26.0,
+            score_quick_arrival=18.0, score_easy_home=10.0,
+            journey_details_json=json.dumps({
+                'outbound': [
+                    {'person': 'Alice', 'direction': 'outbound',
+                     'time_minutes': 12.0, 'lines': ['Jubilee']},
+                    {'person': 'Bob', 'direction': 'outbound',
+                     'time_minutes': 18.0, 'lines': ['Northern']},
+                ],
+                'return': [
+                    {'person': 'Alice', 'direction': 'return',
+                     'time_minutes': 10.0, 'lines': ['Northern']},
+                    {'person': 'Bob', 'direction': 'return',
+                     'time_minutes': 10.0, 'lines': ['Northern']},
+                ],
+            }),
+            google_maps_url='https://www.google.com/maps/search/?api=1&query=51.5036,-0.1143',
+        )
+        return session
+
     @patch('meetup.views.get_line_disruptions')
-    @patch('meetup.views.calculate_meetup_spots')
-    def test_results_page_loads(self, mock_calc, mock_disruptions):
+    def test_results_page_loads_from_db(self, mock_disruptions):
+        """Results page should load saved results from DB, not re-calculate."""
         mock_disruptions.return_value = []
-        mock_calc.return_value = {
-            'fairness': [{
-                'station_id': 1, 'station_name': 'Test Station',
-                'lat': 51.5, 'lon': -0.1, 'score': 10.0,
-                'outbound_details': [], 'return_details': [],
-                'lines_used': [], 'google_maps_url': 'https://example.com',
-            }],
-            'efficiency': [],
-            'quick_arrival': [],
-            'easy_home': [],
-        }
+        session = self._create_session_with_results()
+
+        response = self.client.get(f'/meetup/results/{session.uuid}/')
+        self.assertEqual(response.status_code, 200)
+        self.assertTemplateUsed(response, 'meetup/results.html')
+
+        # Verify the template context has all 4 modes
+        context_results = response.context['results']
+        for mode in ['fairness', 'efficiency', 'quick_arrival', 'easy_home']:
+            self.assertIn(mode, context_results)
+            self.assertGreater(len(context_results[mode]), 0)
+
+    @patch('meetup.views.get_line_disruptions')
+    def test_results_sorted_by_mode_score(self, mock_disruptions):
+        """Each mode's results should be sorted by that mode's score."""
+        mock_disruptions.return_value = []
+        session = self._create_session_with_results()
+
+        response = self.client.get(f'/meetup/results/{session.uuid}/')
+        context_results = response.context['results']
+
+        # Fairness: Bank (25.0) should come before Waterloo (28.0)
+        self.assertEqual(context_results['fairness'][0]['station_name'], 'Bank')
+        # Efficiency: Waterloo (26.0) should come before Bank (30.0)
+        self.assertEqual(context_results['efficiency'][0]['station_name'], 'Waterloo')
+        # Easy home: Waterloo (10.0) should come before Bank (12.0)
+        self.assertEqual(context_results['easy_home'][0]['station_name'], 'Waterloo')
+
+    @patch('meetup.views.get_line_disruptions')
+    def test_results_checks_live_disruptions(self, mock_disruptions):
+        """Results page should check live TfL disruptions for lines in results."""
+        mock_disruptions.return_value = [
+            {'line': 'Central', 'status': 'Severe Delays', 'reason': ''},
+        ]
+        session = self._create_session_with_results()
+
+        response = self.client.get(f'/meetup/results/{session.uuid}/')
+        self.assertEqual(len(response.context['disruptions']), 1)
+        # Should have called disruptions check with lines from journey details
+        mock_disruptions.assert_called_once()
+        called_lines = mock_disruptions.call_args[0][0]
+        self.assertIn('Central', called_lines)
+
+    @patch('meetup.views.get_line_disruptions')
+    def test_results_no_saved_results_shows_error(self, mock_disruptions):
+        """A session with no saved results should show an error."""
+        mock_disruptions.return_value = []
         session = MeetupSession.objects.create()
         Person.objects.create(
             session=session, name='Alice',
             origin_label='A', origin_lat=51.5, origin_lon=-0.1,
             home_label='B', home_lat=51.5, home_lon=-0.1,
         )
-        Person.objects.create(
-            session=session, name='Bob',
-            origin_label='C', origin_lat=51.48, origin_lon=-0.12,
-            home_label='D', home_lat=51.48, home_lon=-0.12,
-        )
 
         response = self.client.get(f'/meetup/results/{session.uuid}/')
         self.assertEqual(response.status_code, 200)
-        self.assertTemplateUsed(response, 'meetup/results.html')
+        context_results = response.context['results']
+        self.assertIn('error', context_results)
 
     def test_invalid_uuid_returns_404(self):
         import uuid


### PR DESCRIPTION
Three targeted improvements to the meetup calculator:

1. Single Dijkstra call: graph.get_journey() returns both time and path
   in one nx.single_source_dijkstra call, replacing the previous pattern
   of calling get_journey_time + get_journey_path separately. This
   roughly halves Dijkstra runs during calculation.

2. Save all scoring modes: calculate() now persists all unique stations
   across all 4 modes (fairness, efficiency, quick_arrival, easy_home)
   with all scores populated, fixing a bug where only the fairness top-5
   was saved.

3. Load results from DB: results() view now reads saved MeetupResult
   records instead of re-running calculate_meetup_spots on every page
   load. Shared links now load instantly. Live TfL disruption checks
   are still performed fresh.

Test suite expanded from 44 to 63 tests:
- New test_disruptions.py (6 tests) covering TfL API parsing, filtering,
  error handling
- Results view tests now use real DB fixtures instead of mocking the
  optimizer, verifying per-mode sorting and DB-backed rendering
- Added tests for field validation, autocomplete POST rejection,
  disruption passthrough, score ordering, all-scores output,
  same-origin-and-home edge case, route symmetry, and get_journey()

https://claude.ai/code/session_015NfCMeC1wUtrTgqvZcQTqQ