### PR TITLE
Add Render deployment config for mobile testing

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -o errexit
+
+pip install -r requirements.txt
+
+python manage.py collectstatic --no-input
+python manage.py migrate

--- a/mysite/settings/render.py
+++ b/mysite/settings/render.py
@@ -1,0 +1,35 @@
+"""
+Django settings for Render deployment.
+"""
+import os
+from .base import *
+
+SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
+
+DEBUG = False
+
+ALLOWED_HOSTS = []
+
+# Allow Render's hostname
+RENDER_EXTERNAL_HOSTNAME = os.environ.get('RENDER_EXTERNAL_HOSTNAME')
+if RENDER_EXTERNAL_HOSTNAME:
+    ALLOWED_HOSTS.append(RENDER_EXTERNAL_HOSTNAME)
+
+# SQLite is fine for a personal portfolio on the free tier
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': BASE_DIR / 'db.sqlite3',
+    }
+}
+
+# Whitenoise for serving static files without a separate web server
+MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STATIC_URL = '/static/'
+
+# Security
+SECURE_SSL_REDIRECT = True
+SESSION_COOKIE_SECURE = True
+CSRF_COOKIE_SECURE = True
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,14 @@
+services:
+  - type: web
+    name: portfolio
+    runtime: python
+    plan: free
+    buildCommand: ./build.sh
+    startCommand: gunicorn mysite.wsgi:application
+    envVars:
+      - key: DJANGO_SETTINGS_MODULE
+        value: mysite.settings.render
+      - key: DJANGO_SECRET_KEY
+        generateValue: true
+      - key: PYTHON_VERSION
+        value: 3.11.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ sqlparse==0.5.3
 python-dotenv==1.0.0
 networkx==3.6.1
 requests==2.32.3
+gunicorn==23.0.0
+whitenoise==6.8.2


### PR DESCRIPTION
- render.yaml with free tier web service config
- build.sh for install, collectstatic, and migrate
- Render-specific Django settings with whitenoise for static files
- Add gunicorn and whitenoise to requirements

https://claude.ai/code/session_01QY79utrrjqoU8FJVW31d2C