### PR TITLE
Add app.py entry point to fix Render deploy

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,1 @@
+from mysite.wsgi import application as app


### PR DESCRIPTION
Render dashboard is configured to run 'gunicorn app:app' but there was
no app module. This bridges to the Django WSGI application.

https://claude.ai/code/session_018GM1qXoA4niCJEHVsDd1F3