### PR TITLE
Fix 400 errors by adding Render hostname to ALLOWED_HOSTS

### DIFF
--- a/mysite/settings/render.py
+++ b/mysite/settings/render.py
@@ -8,7 +8,7 @@ SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 DEBUG = False
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['portfolio-1-mavz.onrender.com']
 
 # Allow Render's hostname
 RENDER_EXTERNAL_HOSTNAME = os.environ.get('RENDER_EXTERNAL_HOSTNAME')

--- a/render.yaml
+++ b/render.yaml
@@ -12,3 +12,8 @@ services:
         generateValue: true
       - key: PYTHON_VERSION
         value: 3.11.11
+      - key: RENDER_EXTERNAL_HOSTNAME
+        fromService:
+          name: portfolio
+          type: web
+          property: host


### PR DESCRIPTION
ALLOWED_HOSTS was empty because RENDER_EXTERNAL_HOSTNAME env var was not
configured, causing Django to reject all requests with 400 Bad Request.
Added the hostname directly and configured render.yaml to also set the
env var from the service property.

https://claude.ai/code/session_01VoiMzUggy51Wkpyzqd3NMZ