### PR TITLE
Fix 400 error: wsgi.py defaulted to wrong settings module

### DIFF
--- a/mysite/settings/render.py
+++ b/mysite/settings/render.py
@@ -8,12 +8,17 @@ SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 
 DEBUG = False
 
-ALLOWED_HOSTS = ['portfolio-1-mavz.onrender.com']
+ALLOWED_HOSTS = [
+    'portfolio-1-mavz.onrender.com',
+    '.onrender.com',
+]
 
 # Allow Render's hostname
 RENDER_EXTERNAL_HOSTNAME = os.environ.get('RENDER_EXTERNAL_HOSTNAME')
 if RENDER_EXTERNAL_HOSTNAME:
     ALLOWED_HOSTS.append(RENDER_EXTERNAL_HOSTNAME)
+
+CSRF_TRUSTED_ORIGINS = ['https://portfolio-1-mavz.onrender.com']
 
 # SQLite is fine for a personal portfolio on the free tier
 DATABASES = {

--- a/mysite/wsgi.py
+++ b/mysite/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings.production')
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'mysite.settings.render')
 
 application = get_wsgi_application()


### PR DESCRIPTION
The WSGI entry point defaulted to mysite.settings.production, which has
ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '').split(',') — resolving
to [''] when the env var isn't set. This caused Django to reject every
request with 400 Bad Request.

Fixed by:
- Changing wsgi.py default to mysite.settings.render (the only WSGI
  deployment target; local dev uses manage.py → development settings)
- Adding .onrender.com wildcard to ALLOWED_HOSTS for robustness
- Adding CSRF_TRUSTED_ORIGINS for Django 4.0+ HTTPS compatibility

https://claude.ai/code/session_01HvrrhBuMaDX6QHWVnoGkPT