### PR TITLE
Fix 500 errors on Render by running migrations at startup

### DIFF
--- a/mysite/settings/render.py
+++ b/mysite/settings/render.py
@@ -31,7 +31,14 @@ DATABASES = {
 
 # Whitenoise for serving static files without a separate web server
 MIDDLEWARE.insert(1, 'whitenoise.middleware.WhiteNoiseMiddleware')
-STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+    },
+}
 STATIC_URL = '/static/'
 
 # Security

--- a/render.yaml
+++ b/render.yaml
@@ -4,7 +4,7 @@ services:
     runtime: python
     plan: free
     buildCommand: ./build.sh
-    startCommand: gunicorn mysite.wsgi:application
+    startCommand: ./start.sh
     envVars:
       - key: DJANGO_SETTINGS_MODULE
         value: mysite.settings.render

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -o errexit
+
+python manage.py migrate --no-input
+exec gunicorn mysite.wsgi:application


### PR DESCRIPTION
The SQLite database loses its tables when Render's ephemeral filesystem
resets between service restarts. Moving migrate to the start command
ensures tables exist before gunicorn serves requests.

Also fixes STATICFILES_STORAGE being silently ignored by Django 5.1
by using the STORAGES dict instead of the deprecated setting.

https://claude.ai/code/session_017Fdbhmmcdm4aFJPBHQFcTQ